### PR TITLE
Fix for looking up multiple users.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -517,22 +517,27 @@ Twitter.prototype.getRetweetedByIds = function(id, params, callback) {
 }
 
 // User resources
-
 Twitter.prototype.showUser = function(id, callback) {
-	// FIXME: handle id-array and id-with-commas as lookupUser
-	//  NOTE: params with commas b0rk between node-oauth and twitter
-	//        https://github.com/ciaranj/node-oauth/issues/7
-	var url = '/users/show.json';
+  // Lookup will take a single id as well as multiple; why not just use it?
+	var url = '/users/lookup.json',
+      params = {};
 
-	var params = {};
-	if (typeof id === 'string')
-		params.screen_name = id;
-	else
-		params.user_id = id;
+  if(typeof id === 'string') {
+    id = id.replace(/^\s+|\s+$/g, '');
+    id = id.split(',');
+  }
+  else if(!(id instanceof Array)) {
+    id = [id];
+  }
+
+  if(parseInt(id[0]))
+    params.user_id = id.toString();
+  else
+    params.screen_name = id.toString();
 
 	this.get(url, params, callback);
 	return this;
-}
+};
 Twitter.prototype.lookupUser
 	= Twitter.prototype.lookupUsers
 	= Twitter.prototype.showUser;


### PR DESCRIPTION
https://github.com/ciaranj/node-oauth/pull/7

Appears to have been fixed.  My test oracle for my proposed fix:

```
    twitter.lookupUsers("63803", function(error, result) {
      if(error) {
        logger.error("Error in single string.");
        return logger.error(error);
      }
      return logger.info(result);
    });

    twitter.lookupUsers("63803 , 648873 , 668423", function(error, result) {
      if(error) {
        logger.error("Error in comma'd string.");
        return logger.error(error);
      }
      return logger.info(result);
    });

    twitter.lookupUsers("63803,648873,668423", function(error, result) {
      if(error) {
        logger.error("Error in comma'd string.");
        return logger.error(error);
      }
      return logger.info(result);
    });

    twitter.lookupUsers(["63803", "648873", "668423"], function(error, result) {
      if(error) {
        logger.error("Error in string array.");
        return logger.error(error);
      }
      return logger.info(result);
    });

    twitter.lookupUsers(63803, function(error, result) {
      if(error) {
        logger.error("Error in single number.");
        return logger.error(error);
      }
      return logger.info(result);
    });

    twitter.lookupUsers([63803, 648873, 668423], function(error, result) {
      if(error) {
        logger.error("Error in number array.");
        return logger.error(error);
      }
      return logger.info(result);
    });
```

Works perfectly.  Any thoughts?
