### PR TITLE
Twitter streaming is now limited to HTTPS.  See https://dev.twitter.com/b

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -40,9 +40,9 @@ function Twitter(options) {
 
 		rest_base: 'https://api.twitter.com/1',
 		search_base: 'http://search.twitter.com',
-		stream_base: 'http://stream.twitter.com/1',
+        	stream_base: 'https://stream.twitter.com/1',
 		user_stream_base: 'https://userstream.twitter.com/2',
-		site_stream_base: 'http://sitestream.twitter.com/2b',
+		site_stream_base: 'http://sitestream.twitter.com/2b'
 
 		secure: false, // force use of https for login/gatekeeper
 		cookie: 'twauth',


### PR DESCRIPTION
Twitter streaming is now limited to HTTPS.  See https://dev.twitter.com/blog/streaming-api-turning-ssl-only-september-29th.  No significant testing done on this, but passing in these paths as the options got me back up & running.
