### PR TITLE
Fix for broken stream/filter params

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -199,11 +199,12 @@ Twitter.prototype.stream = function(method, params, callback) {
     params = null;
   }
 
-  if (Array.isArray(params)) {
-    params.forEach(function (item) {
-      params[item] = params[item].join(',');
-    });
-  }
+  // Iterate on params properties, if any property is an array, convert it to comma-delimited string
+  Object.keys(params).forEach(function(item) {
+      if (Array.isArray(params[item])) {
+        params[item] = params[item].join(',');
+      }
+  });
 
   var stream_base = this.options.stream_base;
 


### PR DESCRIPTION
Hello. I recently updated to 0.2.6 of ntwitter - to get the HTTPS stream fix - and found that it broke my existing stream/filter implementation.

I found the problem in the bit of new code to generically handle building out the params string inside of Twitter.prototype.stream

I believe that my fix was probably your original intended behavior for this code-block wherein each property of the params object is iterated over, checked if it is an array, and then if so, a comma-delimited string is built and assigned to that property in lieu of an array.

Hope this is helpful. Thanks for the great library!

-jonathan
