### PR TITLE
Support new cookies library, also alternatives to using that cookies library

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -2,7 +2,8 @@ var VERSION = '0.2.0',
   http = require('http'),
   querystring = require('querystring'),
   oauth = require('oauth'),
-  cookie = require('cookies'),
+  Cookies = require('cookies'),
+  Keygrip = require('keygrip'),
   streamparser = require('./parser');
 
 function merge(defaults, options) {
@@ -260,9 +261,17 @@ Twitter.prototype.stream = function(method, params, callback) {
  * and helpful utilities to retrieve the twauth cookie etc.
  */
 Twitter.prototype.cookie = function(req) {
+  var keys = null;
+  if ( !this.options.cookie_secret !== null )
+    keys = new Keygrip(this.options.cookie_secret);
+  var cookies = new Cookies( req, null, keys )
+  var getState = this.options.getState || function (req, key) {
+    return cookies.get(key);
+  };
+
   // Fetch the cookie
   try {
-    var twauth = JSON.parse(req.getSecureCookie(this.options.cookie));
+    var twauth = JSON.parse(getState(req, this.options.cookie));
   } catch (error) {
     var twauth = null;
   }
@@ -280,11 +289,21 @@ Twitter.prototype.login = function(mount, success) {
   if ( this.options.secure && !this.options.cookie_options.secure )
     this.options.cookie_options.secure = true;
   // Set up the cookie encryption secret if we've been given one
-  if ( !cookie.secret && this.options.cookie_secret !== null )
-    cookie.secret = this.options.cookie_secret;
+  var keys = null;
+  if ( !this.options.cookie_secret !== null )
+    keys = new Keygrip(this.options.cookie_secret);
   // FIXME: ^ so configs that don't use login() won't work?
 
   return function handle(req, res, next) {
+    // state
+    var cookies = new Cookies( req, res, keys )
+    var setState = self.options.setState || function (res, key, value) {
+      cookies.set(key, value, self.options.cookie_options);
+    };
+    var clearState = self.options.clearState || function (res, key) {
+      cookies.set(key);
+    };
+
     var path = url.parse(req.url, true);
 
     // We only care about requests against the exact mount point
@@ -323,12 +342,12 @@ Twitter.prototype.login = function(mount, success) {
           // FIXME: do something more intelligent
           return next(500);
         } else {
-          res.setSecureCookie(self.options.cookie, JSON.stringify({
+          setState(res, self.options.cookie, JSON.stringify({
             user_id: user_id,
             screen_name: screen_name,
             access_token_key: access_token_key,
             access_token_secret: access_token_secret
-          }), self.options.cookie_options);
+          }));
           res.writeHead(302, {'Location': success || '/'});
           res.end();
           return;
@@ -343,10 +362,10 @@ Twitter.prototype.login = function(mount, success) {
           // FIXME: do something more intelligent
           return next(500);
         } else {
-          res.setSecureCookie(self.options.cookie, JSON.stringify({
+          setState(res, self.options.cookie, JSON.stringify({
             oauth_token: oauth_token,
             oauth_token_secret: oauth_token_secret
-          }), self.options.cookie_options);
+          }));
           res.writeHead(302, {
             'Location': self.options.authorize_url + '?'
               + querystring.stringify({oauth_token: oauth_token})
@@ -359,7 +378,7 @@ Twitter.prototype.login = function(mount, success) {
     // Broken cookie, clear it and return to originating page
     // FIXME: this is dumb
     } else {
-      res.clearCookie(self.options.cookie);
+      clearState(res, self.options.cookie);
       res.writeHead(302, {'Location': mount});
       res.end();
       return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
 	"name": "ntwitter", 
-	"version": "v0.2.6-1", 
+	"version": "0.2.7", 
 	"description": "Asynchronous Twitter REST/stream/search client API for node.js.", 
 	"keywords": ["twitter","streaming","oauth"], 
 	"homepage": "https://github.com/AvianFlu/ntwitter", 
@@ -17,7 +17,8 @@
   	"dependencies":
   		{ 
 	  		"oauth": ">=0.8.4", 
-  			"cookies": "0.1.x"
+  			"cookies": "0.1.x",
+                        "keygrip": "0.1.x"
   		}, 
   	"engines": ["node 0.4.x"], 
   	"main": "./lib/twitter"


### PR DESCRIPTION
Updates to the new cookie library (key grip now listed as a dependency). Also give the option of setting twitter.options.getState/setState/clearState to use your own session saving.
