### PR TITLE
emit the 'destroy' event when response has been closed

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -233,6 +233,9 @@ Twitter.prototype.stream = function(method, params, callback) {
       request.abort(); // node v0.4.0
     else
       request.socket.destroy();
+    
+    // emit the 'destroy' event
+    stream.emit("destroy","socket has been destroyed");
   };
 
   request.on('response', function(response) {
@@ -247,6 +250,17 @@ Twitter.prototype.stream = function(method, params, callback) {
     response.on('end', function() {
       stream.emit('end', response);
     });
+    
+    /* 
+     * This is a net.Socket event.
+     * When twitter closes the connectionm no 'end/error' event is fired.
+     * In this way we can able to catch this event and force to destroy the 
+     * socket. So, 'stream' object will fire the 'destroy' event as we can see above.
+     */
+    response.on("close", function() {
+      stream.destroy();
+    });
+    
   });
   request.on('error', function(error) {
     stream.emit('error', error);


### PR DESCRIPTION
Hi,
Twitter destroys the connection when another client with the same credentials is connected.
The 'end/close' event on response is never fired because the 'close' event is bound on the net.Socket lib.

What you think about my fix?

Thanks in advance

Fabio
