### PR TITLE
Much more meaningful exceptions if no callback passed

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -99,11 +99,11 @@ Twitter.prototype.get = function(url, params, callback) {
     else {
       try {
         var json = JSON.parse(data);
-        callback(null, json);
       } 
       catch(err) {
-        callback(err);
+        return callback(err);
       }
+      callback(null, json);
     }
   });
   return this;


### PR DESCRIPTION
Without that patch I get something like:

```
/home/gentoo/projects/test/node_modules/ntwitter/lib/twitter.js:1198
    if (data[key]) result = result.concat(data[key]);
            ^
TypeError: Cannot read property 'ids' of undefined
    at fetch (/home/gentoo/projects/test/node_modules/ntwitter/lib/twitter.js:1198:13)
    at /home/gentoo/projects/test/node_modules/ntwitter/lib/twitter.js:105:9
    at passBackControl (/usr/lib/node_modules/oauth/lib/oauth.js:359:11)
    at IncomingMessage.<anonymous> (/usr/lib/node_modules/oauth/lib/oauth.js:378:9)
    at IncomingMessage.emit (events.js:88:20)
    at HTTPParser.onMessageComplete (http.js:137:23)
    at CleartextStream.ondata (http.js:1116:24)
    at CleartextStream._push (tls.js:363:27)
    at SecurePair.cycle (tls.js:666:20)
    at EncryptedStream.write (tls.js:122:13)
```

But with it:

```
/home/gentoo/projects/test/test.js:64
                callback(undefined, self.followers);
                ^
TypeError: undefined is not a function
    at /home/gentoo/projects/test/test.js:64:17
    at fetch (/home/gentoo/projects/test/node_modules/ntwitter/lib/twitter.js:1201:7)
    at /home/gentoo/projects/test/node_modules/ntwitter/lib/twitter.js:106:7
    at passBackControl (/usr/lib/node_modules/oauth/lib/oauth.js:359:11)
    at IncomingMessage.<anonymous> (/usr/lib/node_modules/oauth/lib/oauth.js:378:9)
    at IncomingMessage.emit (events.js:88:20)
    at HTTPParser.onMessageComplete (http.js:137:23)
    at CleartextStream.ondata (http.js:1116:24)
    at CleartextStream._push (tls.js:363:27)
    at SecurePair.cycle (tls.js:666:20)
```

I've lost a couple of hours to find a bug in your code when it was partly in mine.

Have a nice day :)
