### PR TITLE
Catching error when getting data with cursors

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1197,6 +1197,10 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
   this.get(url, params, fetch);
 
   function fetch(err, data) {
+    if (err) {
+      return callback(err);
+    }
+
     // FIXME: what if data[key] is not a list?
     if (data[key]) result = result.concat(data[key]);
 


### PR DESCRIPTION
If twitter returs error in the middle of getting long list by cursors we should callback with error, not just skip it, right?
