### PR TITLE
Stream param list exceeds URL length

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -224,9 +224,10 @@ Twitter.prototype.stream = function(method, params, callback) {
   var url = stream_base + '/' + escape(method) + '.json';
 
   var request = this.oauth.post(
-    url + '?' + querystring.stringify(params),
+    url,
     this.options.access_token_key,
-    this.options.access_token_secret
+    this.options.access_token_secret,
+    params
   );
 
   var stream = new streamparser();


### PR DESCRIPTION
streaming API used to fail when having thousands of parameters in the 'follow' or 'track', because of url length exceeded. This fix avoids 'socket hang up' errors as params are now moved to the body of the POST request.

basically i just ported @stevenewey's correction on node-twitter: https://github.com/jdub/node-twitter/pull/20
