### PR TITLE
stream emit error with http status greater than 200

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -227,20 +227,25 @@ Twitter.prototype.stream = function(method, params, callback) {
     url,
     this.options.access_token_key,
     this.options.access_token_secret,
-    params
+    params, null
   );
 
   var stream = new streamparser();
-  stream.destroy = function() {
-    // FIXME: should we emit end/close on explicit destroy?
+
+  stream.destroySilent = function() {
     if ( typeof request.abort === 'function' )
       request.abort(); // node v0.4.0
     else
       request.socket.destroy();
-    
+  };
+  stream.destroy = function() {
+    // FIXME: should we emit end/close on explicit destroy?
+    stream.destroySilent();
+
     // emit the 'destroy' event
     stream.emit('destroy','socket has been destroyed');
   };
+
   
   stream.on('_data', processTweet);
 
@@ -260,28 +265,36 @@ Twitter.prototype.stream = function(method, params, callback) {
   }
 
   request.on('response', function(response) {
-    // FIXME: Somehow provide chunks of the response when the stream is connected
-    // Pass HTTP response data to the parser, which raises events on the stream
-    response.on('data', function(chunk) {
-      stream.receive(chunk);
-    });
-    response.on('error', function(error) {
-      stream.emit('error', error);
-    });
-    response.on('end', function() {
-      stream.emit('end', response);
-    });
-    
-    /* 
-     * This is a net.Socket event.
-     * When twitter closes the connectionm no 'end/error' event is fired.
-     * In this way we can able to catch this event and force to destroy the 
-     * socket. So, 'stream' object will fire the 'destroy' event as we can see above.
-     */
-    response.on('close', function() {
-      stream.destroy();
-    });
-    
+
+    // Any response code greater then 200 from steam API is an error
+    if(response.statusCode > 200) {
+      stream.destroySilent();
+      stream.emit('error', 'http', response.statusCode );
+    }
+    else
+    {
+      // FIXME: Somehow provide chunks of the response when the stream is connected
+      // Pass HTTP response data to the parser, which raises events on the stream
+      response.on('data', function(chunk) {
+        stream.receive(chunk);
+      });
+      response.on('error', function(error) {
+        stream.emit('error', error);
+      });
+      response.on('end', function() {
+        stream.emit('end', response);
+      });
+      
+      /* 
+       * This is a net.Socket event.
+       * When twitter closes the connectionm no 'end/error' event is fired.
+       * In this way we can able to catch this event and force to destroy the 
+       * socket. So, 'stream' object will fire the 'destroy' event as we can see above.
+       */
+      response.on('close', function() {
+        stream.destroy();
+      });
+    }
   });
   request.on('error', function(error) {
     stream.emit('error', error);


### PR DESCRIPTION
I needed to create a simple persistent process that always reconnects ( https://gist.github.com/bc83e77307aa969f211f ). I followed concepts at ( https://dev.twitter.com/docs/streaming-api/concepts ) and needed to know explicitly when there was http error.  I made a slight changes in the stream method.  Feel free to include or re-factor.
