### PR TITLE
fixed get arguments for getRetweets and blockExists

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -555,7 +555,7 @@ Twitter.prototype.retweetStatus = function(id, callback) {
 
 Twitter.prototype.getRetweets = function(id, params, callback) {
   var url = '/statuses/retweets/' + escape(id) + '.json';
-  this.get(url, params, null, callback);
+  this.get(url, params,  callback);
   return this;
 }
 
@@ -1070,7 +1070,7 @@ Twitter.prototype.blockExists = function(id, callback) {
   else
     params.user_id = id;
 
-  this.get(url, params, null, callback);
+  this.get(url, params, callback);
   return this;
 }
 Twitter.prototype.isBlocked


### PR DESCRIPTION
Fixed 'INVALID CALLBACK' error in `getRetweets()` and 'blockExists()' method 
