### PR TITLE
Fixed null error when merging params

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -155,7 +155,7 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 Twitter.prototype.search = function(q, params, callback) {
   if (typeof params === 'function') {
     callback = params;
-    params = null;
+    params = {};
   }
 
   if ( typeof callback !== 'function' ) {


### PR DESCRIPTION
This commit fixed the null error when merging params and q.
