### PR TITLE
move callback out of try block in twitter.post

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -138,11 +138,11 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
     else {
       try {
         var json = JSON.parse(data);
-        callback(null, json);
       } 
       catch(err) {
-        callback(err);
+        return callback(err);
       }
+      callback(null, json);
     }
   });
   return this;


### PR DESCRIPTION
Bugfix for `twitter.post` calling its callback within the try/catch json parsing block and then calling it again with the error if it throws the first time.
