### PR TITLE
reformat and make small changes to wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Asynchronous Twitter client API for node.js
 ===========================================
 
-[ntwitter](http://github.com/AvianFlu/ntwitter) is an upgraded version of jdub's [node-twitter](http://github.com/jdub/node-twitter), which in turn was inspired by, and uses some code from, technoweenie's [twitter-node](http://github.com/technoweenie/twitter-node).
+[ntwitter](http://github.com/AvianFlu/ntwitter) is an improved version of jdub's [node-twitter](http://github.com/jdub/node-twitter), which in turn was inspired by, and uses some code from, technoweenie's [twitter-node](http://github.com/technoweenie/twitter-node).
+
 
 ## Installation
 
@@ -12,31 +13,36 @@ You can install ntwitter and its dependencies with npm: `npm install ntwitter`.
 
 This library is, for the most part, the same API as `node-twitter`. Much of the documentation below is straight from `node-twitter` - credit goes to [jdub](http://github.com/jdub) for putting all this together in the first place. 
 
-The most significant API change involves error handling in callbacks.  Callbacks should now look something like this:
+The most significant API change involves error handling in callbacks. Callbacks now receive the error as a separate parameter, rather than as part of the data. This is consistent with node's standard library. Callbacks should now look something like this:
 
-         function (err, result) {
-           if (err) {return callback(err)}
-           // Do something with 'result' here
-         }
+``` javascript
+function (err, result) {
+  if (err) return callback(err);
+
+  // Do something with 'result' here
+}
+```
 
 Where `callback` is the parent function's callback.  (Or any other function you want to call on error.)
 
+
 ### Setup API 
 
-The keys listed below can be obtained from [dev.twitter.com](http://dev.twitter.com) after setting up a new App.
+The keys listed below can be obtained from [dev.twitter.com](http://dev.twitter.com) after [setting up a new App](https://dev.twitter.com/apps/new).
 
-        var twitter = require('ntwitter');
+``` javascript
+var twitter = require('ntwitter');
 
-        var twit = new twitter({
-          consumer_key: 'Twitter',
-          consumer_secret: 'API',
-          access_token_key: 'keys',
-          access_token_secret: 'go here'
-        });
+var twit = new twitter({
+  consumer_key: 'Twitter',
+  consumer_secret: 'API',
+  access_token_key: 'keys',
+  access_token_secret: 'go here'
+});
+```
 
 
 ### REST API 
-
 
 Interaction with other parts of Twitter is accomplished through their RESTful API.
 The best documentation for this exists at [dev.twitter.com](http://dev.twitter.com).  Convenience methods exist
@@ -46,61 +52,71 @@ Twitter's current documentation.
 
 Note that all functions may be chained:
 
-        twit
-          .verifyCredentials(function (err, data) {
-            console.log(data);
-          })
-          .updateStatus('Test tweet from ntwitter/' + twitter.VERSION,
-            function (err, data) {
-              console.log(data);
-            }
-          );
+``` javascript
+twit
+  .verifyCredentials(function (err, data) {
+    console.log(data);
+  })
+  .updateStatus('Test tweet from ntwitter/' + twitter.VERSION,
+    function (err, data) {
+      console.log(data);
+    }
+  );
+```
 
 ### Search API 
 
-		twit.search('nodejs OR #node', {}, function(err, data) {
-		  console.log(data);
-		});
+``` javascript
+twit.search('nodejs OR #node', {}, function(err, data) {
+  console.log(data);
+});
+```
 
 ### Streaming API 
 
-The stream() callback receives a Stream-like EventEmitter:
+The stream() callback receives a Stream-like EventEmitter.
 
-Here is an example of how to call the 'statuses/sample' method:
+Here is an example of how to call the `statuses/sample` method:
 
-        twit.stream('statuses/sample', function(stream) {
-          stream.on('data', function (data) {
-            console.log(data);
-          });
-        });
+``` javascript
+twit.stream('statuses/sample', function(stream) {
+  stream.on('data', function (data) {
+    console.log(data);
+  });
+});
+```
         
 Here is an example of how to call the 'statuses/filter' method with a bounding box over San Fransisco and New York City ( see streaming api for more details on [locations](https://dev.twitter.com/docs/streaming-api/methods#locations) ):
 
-        twit.stream('statuses/filter', {'locations':'-122.75,36.8,-121.75,37.8,-74,40,-73,41'}, function(stream) {
-          stream.on('data', function (data) {
-            console.log(data);
-          });
-        });
+``` javascript
+twit.stream('statuses/filter', {'locations':'-122.75,36.8,-121.75,37.8,-74,40,-73,41'}, function(stream) {
+  stream.on('data', function (data) {
+    console.log(data);
+  });
+});
+```
 
 ntwitter also supports user and site streams:
 
-        twit.stream('user', {track:'nodejs'}, function(stream) {
-          stream.on('data', function (data) {
-            console.log(data);
-          });
-          stream.on('end', function (response) {
-            // Handle a disconnection
-          });
-          stream.on('destroy', function (response) {
-            // Handle a 'silent' disconnection from Twitter, no end/error event fired
-          });
-          // Disconnect stream after five seconds
-          setTimeout(stream.destroy, 5000);
-        });
+``` javascript
+twit.stream('user', {track:'nodejs'}, function(stream) {
+  stream.on('data', function (data) {
+    console.log(data);
+  });
+  stream.on('end', function (response) {
+    // Handle a disconnection
+  });
+  stream.on('destroy', function (response) {
+    // Handle a 'silent' disconnection from Twitter, no end/error event fired
+  });
+  // Disconnect stream after five seconds
+  setTimeout(stream.destroy, 5000);
+});
+```
 
 ## Contributors
 
-[Lots of people contribute to this project.  You should too!](https://github.com/AvianFlu/ntwitter/contributors)
+[Lots of people contribute to this project. You should too!](https://github.com/AvianFlu/ntwitter/contributors)
 
 ## TODO
 


### PR DESCRIPTION
I did some work on the README. The main changes were fencing code blocks so the code is syntax highlighted on GitHub, and making the note about the callback error handling change clearer. Please let me know if you'd like anything changed before you're ready to merge!
