### PR TITLE
Update keygrip to 0.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": { 
     "oauth": ">=0.8.4", 
     "cookies": "0.1.x",
-    "keygrip": "0.1.x"
+    "keygrip": "0.2.x"
   }, 
   "engines": {"node":">=0.4.0"}, 
   "main": "./lib/twitter"


### PR DESCRIPTION
Upgrade keygrip dependency to 0.2.x. Nothing seems to break and it's required for node 0.8
