### PR TITLE
Change trends endpoint to new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/config.json
+node_modules

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -652,13 +652,18 @@ Twitter.prototype.userProfileImage = function(id, params, callback) {
 // Trends resources
 
 Twitter.prototype.getTrends = function(callback) {
-  var url = '/trends.json';
-  this.get(url, null, callback);
+  this.getTrendsWithId('1', null, callback);
   return this;
 }
 
 Twitter.prototype.getCurrentTrends = function(params, callback) {
-  var url = '/trends/current.json';
+  this.getTrendsWithId('1', params, callback);
+  return this;
+}
+
+Twitter.prototype.getTrendsWithId = function(woeid, params, callback) {
+  if (!woeid) woeid = '1';
+  var url = '/trends/' + woeid + '.json';
   this.get(url, params, callback);
   return this;
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "cookies": "0.1.x",
     "keygrip": "0.2.x"
   }, 
+  "devDependencies": {
+    "should": "*",
+    "mocha": "*"
+  },
   "engines": {"node":">=0.4.0"}, 
   "main": "./lib/twitter"
 }

--- a/test/trend.js
+++ b/test/trend.js
@@ -1,0 +1,43 @@
+var ntwitter = require('../index.js'),
+    mocha = require('mocha'),
+    should = require('should'),
+    fs = require('fs'),
+    config = JSON.parse(fs.readFileSync('./config.json'));
+
+var twitter = new ntwitter({
+  consumer_key: config.key,
+  consumer_secret: config.secret,
+  access_token_key: config.token_key,
+  access_token_secret: config.token_secret
+});
+
+describe('Twitter Trend API', function() {
+  it('Origin getTrends still work', function(done) {
+    twitter.getTrends(function(err, data) {
+      data[0].trends.should.not.be.empty;
+      done();
+    });
+  });
+
+  it('Origin getCurrentTrends still work', function(done) {
+    twitter.getCurrentTrends(function(err, data) {
+      data[0].trends.should.not.be.empty;
+      done();
+    });
+  });
+
+  it('GET trends/:woeid data without earth id', function(done) {
+    twitter.getTrendsWithId(null, function(err, data) {
+      data[0].trends.should.not.be.empty;
+      done();
+    });
+  });
+
+  it('GET trends/:woeid data wih earth id', function(done) {
+    twitter.getTrendsWithId('23424977', function(err, data) {
+      data[0].trends.should.not.be.empty;
+      data[0].locations[0].name.should.equal('United States');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Based on #66,  add a new function getTrendsWithId for new trends endpoint and modify getTrends and getCurrentTrends, some users still using these two function won't be influence. Include a simple test case too.
