### PR TITLE
using API v1.1 endpoints

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -4,10 +4,10 @@ module.exports = {
     access_token_url: 'https://api.twitter.com/oauth/access_token',
     authenticate_url: 'https://api.twitter.com/oauth/authenticate',
     authorize_url: 'https://api.twitter.com/oauth/authorize',
-    rest_base: 'https://api.twitter.com/1',
+    rest_base: 'https://api.twitter.com/1.1',
     search_base: 'http://search.twitter.com',
-          stream_base: 'https://stream.twitter.com/1',
-    user_stream_base: 'https://userstream.twitter.com/2',
-    site_stream_base: 'https://sitestream.twitter.com/2b'
+          stream_base: 'https://stream.twitter.com/1.1',
+    user_stream_base: 'https://userstream.twitter.com/1.1',
+    site_stream_base: 'https://sitestream.twitter.com/1.1'
 	}
 };


### PR DESCRIPTION
This updates the resource URLs to v1.1

Twitter recently updated this.
