### PR TITLE
Automatically throttle requests based on Twitter's API rate limit

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1015,9 +1015,14 @@ Twitter.prototype.getFollowersIds = function(id, callback) {
 
 // Account resources
 
-Twitter.prototype.verifyCredentials = function(callback) {
+Twitter.prototype.verifyCredentials = function(skip_status, callback) {
+  if (typeof skip_status === 'function') {
+    callback = skip_status;
+    skip_status = false;
+  }
+
   var url = '/account/verify_credentials.json';
-  this.get(url, null, callback);
+  this.get(url, {skip_status: skip_status}, callback);
   return this;
 }
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -64,13 +64,19 @@ Twitter.prototype.get = function(url, params, callback) {
     this.options.access_token_key,
     this.options.access_token_secret,
   function(error, data, response) {
+    var rate_limit = {
+      'reset': response.headers['x-rate-limit-reset'],
+      'remaining': response.headers['x-rate-limit-remaining'],
+      'total': response.headers['x-rate-limit-limit']
+    };
+
     if ( error && error.statusCode ) {
       var err = new Error('HTTP Error '
         + error.statusCode + ': '
         + http.STATUS_CODES[error.statusCode]);
       err.statusCode = error.statusCode;
       err.data = error.data;
-      callback(err);
+      callback(err, rate_limit);
     } 
     else if (error) {
       callback(error);
@@ -82,7 +88,8 @@ Twitter.prototype.get = function(url, params, callback) {
       catch(err) {
         return callback(err);
       }
-      callback(null, json);
+
+      callback(null, json, rate_limit);
     }
   });
   return this;
@@ -1247,6 +1254,8 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
     key = params.key || null,
     result = [];
 
+	var TOO_MANY_REQUESTS_STATUS_CODE = 429;
+
   // if we don't have a key to fetch, we're screwed
   if (!key)
     callback(new Error('FAIL: Results key must be provided to _getUsingCursor().'));
@@ -1256,19 +1265,53 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
   params = utils.merge(params, {cursor:-1});
   this.get(url, params, fetch);
 
-  function fetch(err, data) {
+  function fetch(err, data, rate_limit) {
     if (err) {
+      rate_limit = data;
+      delete data;
+    }
+
+    var is_too_many_requests = (err && err.statusCode === TOO_MANY_REQUESTS_STATUS_CODE);
+
+    if (err && !is_too_many_requests) {
       return callback(err);
     }
 
-    // FIXME: what if data[key] is not a list?
-    if (data[key]) result = result.concat(data[key]);
-
-    if (data.next_cursor_str === '0') {
-      callback(null, result);
-    } else {
-      params.cursor = data.next_cursor_str;
+    var should_throttle = false;
+    var next_call = function() {
       self.get(url, params, fetch);
+    };
+
+    if (is_too_many_requests) {
+      // this is going to repeat the last request
+      should_throttle = true;
+    } else if (rate_limit.remaining == 0) {
+      should_throttle = true;
+    }
+
+    // fetch next set or finish
+    if (!is_too_many_requests) {
+      // FIXME: what if data[key] is not a list?
+      if (data[key]) result = result.concat(data[key]);
+
+      if (data.next_cursor_str === '0') {
+        next_call = function() {
+          callback(null, result);
+        }
+        should_throttle = false;
+      } else {
+        params.cursor = data.next_cursor_str;
+      }
+    }
+
+    if (should_throttle) {
+      var now = Math.ceil(new Date().getTime() / 1000);
+      var seconds_until_window_ends = rate_limit.reset - now;
+
+      // a second after, just in case
+      setTimeout(next_call, (seconds_until_window_ends + 1) * 1000);
+    } else {
+      next_call();
     }
   }
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1311,7 +1311,7 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
 
     if (should_throttle) {
       var now = Math.ceil(new Date().getTime() / 1000);
-      var seconds_until_window_ends = rate_limit.reset - now;
+      var seconds_until_window_ends = Math.max(0, rate_limit.reset - now);
 
       // a second after, just in case
       setTimeout(next_call, (seconds_until_window_ends + 1) * 1000);

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -64,11 +64,11 @@ Twitter.prototype.get = function(url, params, callback) {
     this.options.access_token_key,
     this.options.access_token_secret,
   function(error, data, response) {
-    var rate_limit = {
+    var rate_limit = response ? {
       'reset': response.headers['x-rate-limit-reset'],
       'remaining': response.headers['x-rate-limit-remaining'],
       'total': response.headers['x-rate-limit-limit']
-    };
+    } : {};
 
     if ( error && error.statusCode ) {
       var err = new Error('HTTP Error '


### PR DESCRIPTION
This will delay the next call when `x-rate-limit-remaining` has reached 0 or when Twitter has returned `429 Too Many Requests`
