### PR TITLE
Fix trends/place API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -663,7 +663,9 @@ Twitter.prototype.getCurrentTrends = function(params, callback) {
 
 Twitter.prototype.getTrendsWithId = function(woeid, params, callback) {
   if (!woeid) woeid = '1';
-  var url = '/trends/' + woeid + '.json';
+  if (!params) params = {};
+  params.id = woeid;
+  var url = '/trends/place.json';
   this.get(url, params, callback);
   return this;
 }


### PR DESCRIPTION
Url has changed between API version 1 and 1.1:

Old one: https://dev.twitter.com/docs/api/1/get/trends/%3Awoeid
New one: https://dev.twitter.com/docs/api/1.1/get/trends/place
