### PR TITLE
Adding params to the showUpdate API function.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -515,9 +515,9 @@ Twitter.prototype.getRetweetedByUser = function(params, callback){
 
 // Tweets resources
 
-Twitter.prototype.showStatus = function(id, callback) {
+Twitter.prototype.showStatus = function(id, params, callback) {
   var url = '/statuses/show/' + escape(id) + '.json';
-  this.get(url, null, callback);
+  this.get(url, params, callback);
   return this;
 }
 Twitter.prototype.getStatus


### PR DESCRIPTION
The 'params' argument would be useful to include the entities in the response, for instance. 
