### PR TITLE
Replace semi-colon with comma in lib/twitter.js to eliminate global leak

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -6,7 +6,7 @@ var VERSION = '0.2.8',
   Keygrip = require('keygrip'),
   streamparser = require('./parser'),
 	util = require('util'),
-	utils = require('./utils');
+	utils = require('./utils'),
 	keys = require('./keys');
 
 function Twitter(options) {


### PR DESCRIPTION
The problem caused the framework to fail tests in some frameworks (I've tried in mocha).
