### PR TITLE
Fix GET favorites/list url. 

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1050,7 +1050,7 @@ Twitter.prototype.updateProfileImg = function (params, callback) {
 // Favorites resources
 
 Twitter.prototype.getFavorites = function(params, callback) {
-  var url = '/favorites.json';
+  var url = '/favorites/list.json';
   this.get(url, params, callback);
   return this;
 }


### PR DESCRIPTION
Url has changed between API version 1 and 1.1. Old one: http://api.twitter.com/version/favorites.json New one: https://api.twitter.com/1.1/favorites/list.json
