### PR TITLE
fix getFavorites url to work with 1.1 REST-API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -71,14 +71,14 @@ Twitter.prototype.get = function(url, params, callback) {
       err.statusCode = error.statusCode;
       err.data = error.data;
       callback(err);
-    } 
+    }
     else if (error) {
       callback(error);
     }
     else {
       try {
         var json = JSON.parse(data);
-      } 
+      }
       catch(err) {
         return callback(err);
       }
@@ -117,7 +117,7 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 				content[e] = content[e].toString();
 		});
   }
-  
+
   this.oauth.post(url,
     this.options.access_token_key,
     this.options.access_token_secret,
@@ -131,14 +131,14 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
       err.data = error.data;
       err.statusCode = error.statusCode;
       callback(err);
-    } 
+    }
     else if (error) {
       callback(error);
     }
     else {
       try {
         var json = JSON.parse(data);
-      } 
+      }
       catch(err) {
         return callback(err);
       }
@@ -194,10 +194,10 @@ Twitter.prototype.stream = function(method, params, callback) {
   // Stream type customisations
   if (method === 'user') {
     stream_base = this.options.user_stream_base;
-  } 
+  }
   else if (method === 'site') {
     stream_base = this.options.site_stream_base;
-  } 
+  }
 
 
   var url = stream_base + '/' + escape(method) + '.json';
@@ -225,7 +225,7 @@ Twitter.prototype.stream = function(method, params, callback) {
     stream.emit('destroy','socket has been destroyed');
   };
 
-  
+
   stream.on('_data', processTweet);
 
   function processTweet(tweet) {
@@ -263,11 +263,11 @@ Twitter.prototype.stream = function(method, params, callback) {
       response.on('end', function() {
         stream.emit('end', response);
       });
-      
-      /* 
+
+      /*
        * This is a net.Socket event.
        * When twitter closes the connectionm no 'end/error' event is fired.
-       * In this way we can able to catch this event and force to destroy the 
+       * In this way we can able to catch this event and force to destroy the
        * socket. So, 'stream' object will fire the 'destroy' event as we can see above.
        */
       response.on('close', function() {
@@ -636,7 +636,7 @@ Twitter.prototype.userProfileImage = function(id, params, callback) {
     this.options.access_token_secret);
   request.on('response', function(response) {
     // return the location or an HTTP error
-    if (!response.headers.location) { 
+    if (!response.headers.location) {
       callback(new Error('HTTP Error '
       + response.statusCode + ': '
       + http.STATUS_CODES[response.statusCode])) }
@@ -947,14 +947,14 @@ Twitter.prototype.outgoingFriendships
 Twitter.prototype.lookupFriendship = function(id, callback) {
   var url = '/friendships/lookup.json',
       params = {}, ids = [], names = [];
-  
+
   if (typeof id === 'string') {
     id = id.replace(/^\s+|\s+$/g, '');
     id = id.split(',');
   }
-  
+
   id = [].concat(id);
-  
+
   id.forEach(function(item) {
     if (parseInt(item, 10)) {
       ids.push(item);
@@ -962,10 +962,10 @@ Twitter.prototype.lookupFriendship = function(id, callback) {
       names.push(item);
     }
   });
-  
+
   params.user_id = ids.toString();
   params.screen_name = names.toString();
-  
+
   this.get(url, params, callback);
   return this;
 };
@@ -1042,7 +1042,7 @@ Twitter.prototype.updateProfileImg = function (params, callback) {
   var url = '/account/update_profile_image.json';
   this.post(url, params, null, callback);
   return this;
-  
+
 }
 
 // FIXME: Account resources section not complete
@@ -1050,7 +1050,7 @@ Twitter.prototype.updateProfileImg = function (params, callback) {
 // Favorites resources
 
 Twitter.prototype.getFavorites = function(params, callback) {
-  var url = '/favorites.json';
+  var url = '/favorites/list.json';
   this.get(url, params, callback);
   return this;
 }


### PR DESCRIPTION
I just changed the `url` in `getFavorites` to work with the 1.1 REST-API and removed some trailing whitespaces
