### PR TITLE
Fix the mentions endpoint

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -478,7 +478,7 @@ Twitter.prototype.getUserTimeline = function(params, callback) {
 }
 
 Twitter.prototype.getMentions = function(params, callback) {
-  var url = '/statuses/mentions.json';
+  var url = '/statuses/mentions_timeline.json';
   this.get(url, params, callback);
   return this;
 }


### PR DESCRIPTION
The twitter v1.1 REST API has renamed this endpoint to /statuses/mentions_timeline. Described here: https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline
