### PR TITLE
GET requests fail when containing (, ), ! or *

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -60,7 +60,14 @@ Twitter.prototype.get = function(url, params, callback) {
   if (url.charAt(0) == '/')
     url = this.options.rest_base + url;
 
-  this.oauth.get(url + '?' + querystring.stringify(params),
+  var param_str = querystring.stringify(params);
+  param_str = param_str.replace(/\!/g, "%21")
+              .replace(/\'/g, "%27")
+              .replace(/\(/g, "%28")
+              .replace(/\)/g, "%29")
+              .replace(/\*/g, "%2A");
+
+  this.oauth.get(url + '?' + param_str,
     this.options.access_token_key,
     this.options.access_token_secret,
   function(error, data, response) {


### PR DESCRIPTION
E.g. when searching for a smiley. 
Same fix and bug as issue #74, but for GET requests.
