### PR TITLE
Add tcp timeout to destroy stream

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -273,6 +273,13 @@ Twitter.prototype.stream = function(method, params, callback) {
       response.on('close', function() {
         stream.destroy();
       });
+
+      //Twitter sends a keep alive newline every 30sec, if 3 cycles pass with no data
+      //the stream is stalled.  Disconnect and re-connect.
+      response.socket.setTimeout(90000, function(){
+        stream.destroySilent();
+        stream.emit('tcpTimeout');
+      });
     }
   });
   request.on('error', function(error) {


### PR DESCRIPTION
Twitter sends a keep alive newline every 30sec, if 3 cycles pass with no data the stream is [stalled](https://dev.twitter.com/docs/streaming-apis/connecting#Stalls). Disconnect and re-connect.  This update along with recent update in [immortal-ntwtitter](https://github.com/horixon/immortal-ntwitter) allows for the stall to be handled and resolves many comments in [issue #20](https://github.com/AvianFlu/ntwitter/issues/20).  May also close [issue #49](https://github.com/AvianFlu/ntwitter/issues/49) 
