### PR TITLE
Making 'get' and 'post' methods more intuitive

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -44,6 +44,33 @@ Twitter.VERSION = VERSION;
 module.exports = Twitter;
 
 /*
+ * Get usable url
+ */
+
+Twitter.prototype.getUrl = function (url, params) {
+
+  var params = params || null;
+ 
+  if (!url.match(/^[\w]+:\/\//)) {
+
+    url = this.options.rest_base + '/' + url;
+
+    if (url.substr(-5) != '.json')
+        url += '.json';
+
+  }
+
+  if (url.charAt(0) == '/')
+    url = url.substr(1);
+ 
+  if (params)
+    url += '?' + querystring.stringify(params);
+
+  return url;
+
+}
+
+/*
  * GET
  */
 Twitter.prototype.get = function(url, params, callback) {
@@ -57,10 +84,7 @@ Twitter.prototype.get = function(url, params, callback) {
     return this;
   }
 
-  if (url.charAt(0) == '/')
-    url = this.options.rest_base + url;
-
-  this.oauth.get(url + '?' + querystring.stringify(params),
+   this.oauth.get(this.getUrl(url, params),
     this.options.access_token_key,
     this.options.access_token_secret,
   function(error, data, response) {
@@ -107,9 +131,6 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
     return this;
   }
 
-  if (url.charAt(0) == '/')
-    url = this.options.rest_base + url;
-
   // Workaround: oauth + booleans == broken signatures
   if (content && typeof content === 'object') {
     Object.keys(content).forEach(function(e) {
@@ -118,7 +139,7 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 		});
   }
   
-  this.oauth.post(url,
+  this.oauth.post(this.getUrl(url),
     this.options.access_token_key,
     this.options.access_token_secret,
     content, content_type,


### PR DESCRIPTION
Sorry my english, this is a small commit. Actualy you need start with "/" and apply the ".json" extension in methods get/post's urls.

This does not intuitive:

``` js
get('/users/show.json',{screen_name: 'exos'}, function (err, res) {
    ...
});
```

instead of presume a url not begun by "/" is a complete URL, I presumed opposite:

``` js
get('users/show',{screen_name: 'exos'}, function (err, res) {
    ...
});
```

In my version is correct, and translate to `https://api.twitter.com/1.1//users/show.json?screen_name=exos`

For compatibility the follows urls are accepted:
- 'users/show'
- '/users/show'
- 'users/show.json'
- '/users/show.json'

But, if an url start with http://, https://, somestring://  the url has considerate absolute. Ex 'http://anotherhost.com/users/show.nojson' is'nt translate.
