### PR TITLE
Fix for search API

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -5,8 +5,8 @@ module.exports = {
     authenticate_url: 'https://api.twitter.com/oauth/authenticate',
     authorize_url: 'https://api.twitter.com/oauth/authorize',
     rest_base: 'https://api.twitter.com/1.1',
-    search_base: 'http://search.twitter.com',
-          stream_base: 'https://stream.twitter.com/1.1',
+    search_base: 'https://api.twitter.com/1.1/search',
+    stream_base: 'https://stream.twitter.com/1.1',
     user_stream_base: 'https://userstream.twitter.com/1.1',
     site_stream_base: 'https://sitestream.twitter.com/1.1'
 	}

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -163,7 +163,7 @@ Twitter.prototype.search = function(q, params, callback) {
     return this;
   }
 
-  var url = this.options.search_base + '/search.json';
+  var url = this.options.search_base + '/tweets.json';
   params = utils.merge(params, {q:q});
   this.get(url, params, callback);
   return this;


### PR DESCRIPTION
"Updated search url for v1.1 of Twitter API, previously was returning 'API not supported' error in response payload"

[master 67e6c98] Updated search url for v1.1 of Twitter API, previously was returning 'API not supported' error in response payload
