### PR TITLE
Updated Twitter Search API to use version 1.1 standard.

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -5,8 +5,7 @@ module.exports = {
     authenticate_url: 'https://api.twitter.com/oauth/authenticate',
     authorize_url: 'https://api.twitter.com/oauth/authorize',
     rest_base: 'https://api.twitter.com/1.1',
-    search_base: 'http://search.twitter.com',
-          stream_base: 'https://stream.twitter.com/1.1',
+    stream_base: 'https://stream.twitter.com/1.1',
     user_stream_base: 'https://userstream.twitter.com/1.1',
     site_stream_base: 'https://sitestream.twitter.com/1.1'
 	}

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -163,7 +163,7 @@ Twitter.prototype.search = function(q, params, callback) {
     return this;
   }
 
-  var url = this.options.search_base + '/search.json';
+  var url =  '/search/tweets.json';
   params = utils.merge(params, {q:q});
   this.get(url, params, callback);
   return this;


### PR DESCRIPTION
- Twitter.prototype.search() url now uses REST_BASE key.
- Removed SEARCH_BASE key, which is not used anymore in version 1.1

Tested in my local environment by running a sample NodeJS application.
