### PR TITLE
search upgraded to twitter api 1.1 url

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -4,9 +4,8 @@ module.exports = {
     access_token_url: 'https://api.twitter.com/oauth/access_token',
     authenticate_url: 'https://api.twitter.com/oauth/authenticate',
     authorize_url: 'https://api.twitter.com/oauth/authorize',
-    rest_base: 'https://api.twitter.com/1.1',
-    search_base: 'http://search.twitter.com',
-          stream_base: 'https://stream.twitter.com/1.1',
+    rest_base: 'https://api.twitter.com/1.1',    
+    stream_base: 'https://stream.twitter.com/1.1',
     user_stream_base: 'https://userstream.twitter.com/1.1',
     site_stream_base: 'https://sitestream.twitter.com/1.1'
 	}

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -163,7 +163,7 @@ Twitter.prototype.search = function(q, params, callback) {
     return this;
   }
 
-  var url = this.options.search_base + '/search.json';
+  var url = this.options.rest_base + '/search/tweets.json';
   params = utils.merge(params, {q:q});
   this.get(url, params, callback);
   return this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
   "name": "ntwitter", 
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Asynchronous Twitter REST/stream/search client API for node.js.", 
   "keywords": ["twitter","streaming","oauth"], 
   "homepage": "https://github.com/AvianFlu/ntwitter", 


### PR DESCRIPTION
version 0.5.0 was not working for doing search
it was using a deprecated api version (1.0) now in 1.1 the url for search is rest_base + /search/tweets.json
I just made the change for this
