### PR TITLE
Fixing rateLimitStatus() according to API 1.1

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1014,12 +1014,6 @@ Twitter.prototype.verifyCredentials = function(callback) {
   return this;
 }
 
-Twitter.prototype.rateLimitStatus = function(callback) {
-  var url = '/account/rate_limit_status.json';
-  this.get(url, null, callback);
-  return this;
-}
-
 Twitter.prototype.updateProfile = function(params, callback) {
   // params: name, url, location, description
   var defaults = {
@@ -1225,6 +1219,12 @@ Twitter.prototype.geoGetPlace = function(place_id, callback) {
 // Legal resources
 
 // Help resources
+
+Twitter.prototype.rateLimitStatus = function(callback) {
+  var url = '/application/rate_limit_status.json';
+  this.get(url, null, callback);
+  return this;
+}
 
 // Streamed Tweets resources
 


### PR DESCRIPTION
After switching to API 1.1 url for rateLimitStatus() has changed. In addition, they moved it to Help section instead of 
Account.

See 
https://dev.twitter.com/docs/api/1.1
https://dev.twitter.com/docs/api/1.1/get/application/rate_limit_status
