### PR TITLE
Fixed getTrendsById for 1.1

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -661,9 +661,23 @@ Twitter.prototype.getCurrentTrends = function(params, callback) {
   return this;
 }
 
+/**
+ * Gets the trends by the given WOEID
+ * @version 1.1
+ * @param woeid
+ * @param params
+ * @param callback
+ * @returns {Twitter}
+ * @author  ArkeologeN <http://github.com/ArkeologeN>
+ */
 Twitter.prototype.getTrendsWithId = function(woeid, params, callback) {
   if (!woeid) woeid = '1';
-  var url = '/trends/' + woeid + '.json';
+  var url = '/trends/place.json';
+  if (typeof params == 'function') {
+      callback = params;
+      params = {};
+      params.id = woeid;
+  }
   this.get(url, params, callback);
   return this;
 }


### PR DESCRIPTION
The old version was throwing unknown errors like 404 and 302 due to the change in Twitter's API from 1 to 1.1. This method now adds `id` as query parameter that holds `WOEID`

PS: Sorry I forgot to initiate new branch for it!
